### PR TITLE
Release version 0.13.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,25 @@ release, breaking changes will increment the minor version only. This is likely
 to happen quite often until things have settled down and a certain degree of
 maturity is established.
 
+Release 0.13.0
+--------------
+
+This release is going to make many variants of the Numato devices compatible.
+
+Those variants' major differences are in the end-of-line sequences of responses
+to queries and notificastions. Worse, in some cases they are not even uniform
+across responses and notifications of a single device variant. Consequently,
+this version now completely discards all end-of-line characters while reading
+which also simplifies the reading code a lot. Discarding is possible as all
+device resonses are either known by their length or are terminated by the
+`>` prompt character.
+
+Breaking change:
+
+Using the notification API on a board that doesn't support notifications (8
+port boards don't) will now raise a NumatoGpioException instead of returning
+False.
+
 Release 0.12.0
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numato-gpio"
-version = "0.13.0a0"
+version = "0.13.0"
 description = "Python API for Numato GPIO Expanders"
 authors = ["Henning Claßen <code@clssn.de>"]
 license = "MIT License"


### PR DESCRIPTION
This release is going to make many variants of the Numato devices compatible.

Those variants' major differences are in the end-of-line sequences of responses
to queries and notificastions. Worse, in some cases they are not even uniform
across responses and notifications of a single device variant. Consequently,
this version now completely discards all end-of-line characters while reading
which also simplifies the reading code a lot. Discarding is possible as all
device resonses are either known by their length or are terminated by the
`>` prompt character.