### PR TITLE
Ignore error when closing an already closed serial connection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers=[
 ]
 dependencies = [
     "pyserial>=3.1,<4",
+    "rich>=14.0.0",
 ]
 
 [project.urls]

--- a/src/numato_gpio/__init__.py
+++ b/src/numato_gpio/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from contextlib import suppress
 from enum import Enum
 from typing import ClassVar
 
@@ -488,8 +489,9 @@ class NumatoUsbGpio:
         try:
             with self._rw_lock:
                 self._ser.write(query)
-        except serial.serialutil.SerialException as err:
-            self._ser.close()
+        except serial.SerialException as err:
+            with suppress(OSError):
+                self._ser.close()
             raise NumatoSerialIoError(err) from err
 
     def _read_expected_string(self, expected: str) -> None:
@@ -622,8 +624,9 @@ class NumatoUsbGpio:
 
                 self._read_notification()
 
-        except (TypeError, serial.serialutil.SerialException):
-            self._ser.close()  # ends the polling loop and its thread
+        except (TypeError, serial.SerialException):
+            with suppress(OSError):
+                self._ser.close()  # ends the polling loop and its thread
 
     def _check_port_range(self, port: int) -> None:
         if port not in range(self.ports):

--- a/src/numato_gpio/__main__.py
+++ b/src/numato_gpio/__main__.py
@@ -1,15 +1,22 @@
 """Main module printing detected numato devices on the command-line."""
 
+from importlib.metadata import version
+
+import rich
+
 from numato_gpio import cleanup, devices, discover
 
 
 def main() -> None:
     """Print out information about all discovered devices."""
     try:
+        rich.print(f"[dim]numato-gpio v{version('numato-gpio')}[/dim]\n")
         discover()
-        print(f"Discovered devices: {'(None)' if not devices else ''}")  # noqa: T201
+        rich.print(
+            f"[bold]Discovered devices: [/bold]{'(None)' if not devices else ''}"
+        )
         for device in devices.values():
-            print(device)  # noqa: T201
+            rich.print(device)
     finally:
         cleanup()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,5 +20,6 @@ def test_main(ports: int, monkeypatch, capsys) -> None:
 
         main()
         cap = capsys.readouterr()
-        assert cap.out.startswith(f"Discovered devices: {os.linesep}dev: /dev/ttyACMxx")
+        assert cap.out.startswith("numato-gpio")
+        assert f"Discovered devices: {os.linesep}dev: /dev/ttyACMxx" in cap.out
         assert cap.err == ""

--- a/uv.lock
+++ b/uv.lock
@@ -113,11 +113,33 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
 name = "numato-gpio"
 version = "0.13.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "pyserial" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -128,7 +150,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyserial", specifier = ">=3.1,<4" }]
+requires-dist = [
+    { name = "pyserial", specifier = ">=3.1,<4" },
+    { name = "rich", specifier = ">=14.0.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -153,6 +178,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -208,6 +242,20 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -244,4 +292,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
 ]


### PR DESCRIPTION
An OSError would be raised when reader and writer threads were concurrently closing the serial connection. One of them would close an already closed connection.

Ideally this would be synchronized so we'd be able to detect an issue closing the connection. In this case a global resource in the system may be broken rendering the system un-usable.

For now we just ignore any issues while closing, not taking a potential later use of the device into account.