### PR TITLE
62-investigate-why-pytest-tests-takes-so-long

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Pre-commit
         run: uv run uvx pre-commit run --all
+        env:
+          SKIP_TESTS: 1
 
       - name: Validate Numato documentation URLs
         run: uv run scripts/broken_urls.py
@@ -63,5 +65,4 @@ jobs:
 
       - name: Test
         run: >
-          find tests -name "test*.py"
-          -exec uv run --python=${{ matrix.python-version }} pytest {} \;
+          uv run --python=${{ matrix.python-version }} pytest tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,6 @@ repos:
         types: [python]
       - id: pytest
         name: Run unit tests
-        entry: uv
-        args: [run, pytest, tests]
+        entry: bash -c '[[ -n "$SKIP_TESTS" ]] || uv run pytest tests'
         language: system
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,9 @@ repos:
         args: [run, mypy]
         language: system
         types: [python]
+      - id: pytest
+        name: Run unit tests
+        entry: uv
+        args: [run, pytest, tests]
+        language: system
+        types: [python]

--- a/src/numato_gpio/__init__.py
+++ b/src/numato_gpio/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from contextlib import suppress
 from enum import Enum
 from functools import cached_property
@@ -614,6 +615,7 @@ class NumatoUsbGpio:
         try:
             while self._ser and self._ser.is_open:
                 if not (b := self._serial_read(1).decode()):
+                    time.sleep(0)
                     continue
 
                 if b != "#":

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,5 +1,6 @@
 """Ensure that notifications are correctly handled anywhere in the input stream."""
 
+import time
 from enum import Enum
 from unittest.mock import Mock
 
@@ -55,7 +56,14 @@ def test_notify(mock_gpio: numato_gpio.NumatoUsbGpio, position: Position) -> Non
             with pytest.raises(numato_gpio.NumatoNotifyNotSupportedError):
                 mock_gpio.add_event_detect(p, cb, numato_gpio.Edge.BOTH)
         port_callbacks.append(cb)
+
+    # query the device to provoke injection of notifications into the response
     mock_gpio.readall()
+
+    if position == Position.BACK:
+        # short delay as readall() returns while the notification is processed
+        time.sleep(0.3)
+
     if mock_gpio.spec.supports_notification:
         for p, cb in enumerate(port_callbacks):
             cb.assert_called_with(p, True)  # noqa: FBT003

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -62,3 +62,4 @@ def test_notify(mock_gpio: numato_gpio.NumatoUsbGpio, position: Position) -> Non
     else:
         assert not any(cb.called for cb in port_callbacks)
     mock_gpio.cleanup()
+    assert not mock_gpio._poll_thread.is_alive()  # noqa: SLF001


### PR DESCRIPTION
Improves the performance, as measured by the unit-tests' runtime by a factor of ~300.

<!-- Brief summary of the PR and its purpose -->

### Changes
- [x] Improve performance
- [x] Run unit-tests in pre-commit hook
- [x] Remove tests-speed workaround in CI

### Checks
- [x] Run code checks now
